### PR TITLE
fix: frontend npm setup

### DIFF
--- a/map-frontend/package.json
+++ b/map-frontend/package.json
@@ -48,6 +48,6 @@
     "karma-coverage": "^2.2.1",
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.1.0",
-    "typescript": "^5.1.0"
+    "typescript": "~5.4.0"
   }
 }

--- a/map-frontend/src/app/map/map.component.ts
+++ b/map-frontend/src/app/map/map.component.ts
@@ -13,7 +13,6 @@ import {
 import * as L from 'leaflet';
 import 'leaflet-responsive-popup';
 import '@elfalem/leaflet-curve';
-import { CombineLatestOperator } from 'rxjs/internal/observable/combineLatest';
 import { ApiService } from '../api.service';
 import { OverlayedPopupComponent } from '../overlayed-popup/overlayed-popup.component';
 import { forkJoin } from 'rxjs';


### PR DESCRIPTION
The version of Angular we use supports up to TypeScript 5.4.x, and our TypeScript version rule was flexible, requiring a version greater than 5.2. With this PR, we limit TypeScript version to be 5.4.x.